### PR TITLE
Fix typo in Customer.

### DIFF
--- a/lib/cielo/api30/customer.rb
+++ b/lib/cielo/api30/customer.rb
@@ -16,7 +16,7 @@ module Cielo
                     :identity,
                     :identity_type,
                     :address,
-                    :delivery_adress
+                    :delivery_address
 
       def initialize(name)
         @name = name
@@ -37,7 +37,7 @@ module Cielo
         customer.identity = data["Identity"]
         customer.identity_type = data["IdentityType"]
         customer.address = Address.from_json(data["Address"])
-        customer.delivery_adress = Address.from_json(data["DeliveryAddress"])
+        customer.delivery_address = Address.from_json(data["DeliveryAddress"])
         customer
       end
 


### PR DESCRIPTION
Proposta de solução para o issue  #9 corrigindo a grafia do attributo `delivery_address`

Obs.: Outra opção seria deixar o atributo com grafia errada `:delivery_adress` e alterar no método `as_json(options={})`