### PR TITLE
Generating/retrieving object DebitCard to/from JSON when payment.type…

### DIFF
--- a/lib/cielo/api30/payment.rb
+++ b/lib/cielo/api30/payment.rb
@@ -71,7 +71,8 @@ module Cielo
         payment.authenticate = data["Authenticate"]
         payment.recurrent = data["Recurrent"]
         payment.recurrent_payment = RecurrentPayment.from_json(data["RecurrentPayment"])
-        payment.credit_card = CreditCard.from_json(data["CreditCard"])
+        payment.credit_card = CreditCard.from_json(
+          (data["Type"] == PAYMENTTYPE_DEBITCARD) ? data["DebitCard"] : data["CreditCard"])
         payment.proof_of_sale = data["ProofOfSale"]
         payment.authorization_code = data["AuthorizationCode"]
         payment.soft_descriptor = data["SoftDescriptor"]
@@ -107,7 +108,7 @@ module Cielo
         Status.success?(status)
       end
 
-      def as_json(options={})
+      def as_json_base(options={})
         {
           ServiceTaxAmount: @service_tax_amount,
           Installments: @installments,
@@ -130,6 +131,12 @@ module Cielo
           Address: @address,
           ReturnInfo: @return_info
         }
+      end
+
+      def as_json(options = {})
+        hash = as_json_base(options)
+        hash[:DebitCard] = hash.delete(:CreditCard) if @type == PAYMENTTYPE_DEBITCARD
+        hash
       end
     end
   end


### PR DESCRIPTION
… is "DebitCard"

Proposta de correção para o issue #10 , garantindo que seja gerado e lido o objeto DebitCard no JSON quando esse for o tipo de pagamento.

Alteração no método `self.from_json(data)`:
- Verificado o parâmetro `data["Type"]`, se este for igual a "DebitCard" o atributo `credit_card` é preenchido com o valor de `data["DebitCard"]`, caso contrário é utilizado o valor de `data["CreditCard"]`.

Alteração no método `as_json(options = {})`:
- Verificando o atributo `type`, se este for igual a "DebitCard" o hash `:CreditCard` é renomeado para `:DebitCard`.